### PR TITLE
Add support for JSF CDI scoped beans picked up from spring configuration classes.

### DIFF
--- a/jsf-spring-boot-integration/src/main/java/org/joinfaces/annotations/JsfCdiToSpring.java
+++ b/jsf-spring-boot-integration/src/main/java/org/joinfaces/annotations/JsfCdiToSpring.java
@@ -17,38 +17,41 @@
 package org.joinfaces.annotations;
 
 import java.util.Set;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.core.type.MethodMetadata;
+import org.springframework.web.context.WebApplicationContext;
 
 /**
  * Convert jsf and cdi enterprise annotation types to spring scope.
  * @author Marcelo Fernandes
  */
-public final class JsfCdiToSpring {
+final class JsfCdiToSpring {
 
 	/**
 	 * Constant for request scope.
 	 */
-	public static final String REQUEST = "request";
+	static final String REQUEST = WebApplicationContext.SCOPE_REQUEST;
 	/**
 	 * Constant for session scope.
 	 */
-	public static final String SESSION = "session";
+	static final String SESSION = WebApplicationContext.SCOPE_SESSION;
 	/**
 	 * Constant for singleton scope.
 	 */
-	public static final String SINGLETON = "singleton";
+	static final String SINGLETON = ConfigurableBeanFactory.SCOPE_SINGLETON;
 	/**
 	 * Constant for prototype scope.
 	 */
-	public static final String PROTOTYPE = "prototype";
+	static final String PROTOTYPE = ConfigurableBeanFactory.SCOPE_PROTOTYPE;
 	/**
 	 * Constant for view scope.
 	 */
-	public static final String VIEW = "view";
+	static final String VIEW = "view";
 
-	protected JsfCdiToSpring() {
+	JsfCdiToSpring() {
 	}
 
-	public static String scopeName(Set<String> annotationTypes) {
+	static String deduceScopeName(Set<String> annotationTypes) {
 		String result = null;
 		if (annotationTypes != null && !annotationTypes.isEmpty()) {
 			if (annotationTypes.contains(
@@ -85,5 +88,31 @@ public final class JsfCdiToSpring {
 			}
 		}
 		return result;
+	}
+
+	static String deduceScopeName(MethodMetadata methodMetadata) {
+		String result = null;
+		if (methodMetadata != null) {
+			if (methodMetadata.isAnnotated(javax.enterprise.context.RequestScoped.class.getName())
+				|| methodMetadata.isAnnotated(javax.faces.bean.RequestScoped.class.getName())) {
+				result = REQUEST;
+			} else if (methodMetadata.isAnnotated(javax.enterprise.context.SessionScoped.class.getName())
+				|| methodMetadata.isAnnotated(javax.faces.bean.SessionScoped.class.getName())) {
+				result = SESSION;
+			} else if (methodMetadata.isAnnotated(javax.enterprise.context.ApplicationScoped.class.getName())
+				|| methodMetadata.isAnnotated(javax.faces.bean.ApplicationScoped.class.getName())) {
+				result = SINGLETON;
+			} else if (methodMetadata.isAnnotated(javax.faces.bean.NoneScoped.class.getName())) {
+				result = PROTOTYPE;
+			} else if (methodMetadata.isAnnotated(javax.faces.view.ViewScoped.class.getName())
+				|| methodMetadata.isAnnotated(javax.faces.bean.ViewScoped.class.getName())) {
+				result = VIEW;
+			} else if (methodMetadata.isAnnotated(javax.enterprise.context.ConversationScoped.class.getName())) {
+				result = SESSION;
+			}
+		}
+
+		return result;
+
 	}
 }

--- a/jsf-spring-boot-integration/src/main/java/org/joinfaces/annotations/JsfCdiToSpringBeanFactoryPostProcessor.java
+++ b/jsf-spring-boot-integration/src/main/java/org/joinfaces/annotations/JsfCdiToSpringBeanFactoryPostProcessor.java
@@ -18,7 +18,6 @@ package org.joinfaces.annotations;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -26,8 +25,11 @@ import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 
 /**
- * Add custom jsf cdi scope implementations.
+ * Add custom JSF CDI scope implementations. Picks up JSF and CDI annotations both on
+ * types and method bean declarations.
+ *
  * @author Marcelo Fernandes
+ * @author Nurettin Yilmaz
  */
 public class JsfCdiToSpringBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
 
@@ -40,18 +42,35 @@ public class JsfCdiToSpringBeanFactoryPostProcessor implements BeanFactoryPostPr
 
 		for (String beanName : clbf.getBeanDefinitionNames()) {
 			BeanDefinition definition = clbf.getBeanDefinition(beanName);
+			registerJsfCdiToSpring(definition);
+		}
+	}
 
-			if (definition instanceof AnnotatedBeanDefinition) {
-				AnnotatedBeanDefinition annDef = (AnnotatedBeanDefinition) definition;
+	/**
+	 * Checks how is bean defined and deduces scope name from JSF CDI annotations
+	 *
+	 * @param definition beanDefinition
+	 */
+	private void registerJsfCdiToSpring(BeanDefinition definition) {
 
-				String scopeName = JsfCdiToSpring.scopeName(annDef.getMetadata().getAnnotationTypes());
-				if (scopeName != null) {
-					definition.setScope(scopeName);
+		if (definition instanceof AnnotatedBeanDefinition) {
+			AnnotatedBeanDefinition annDef = (AnnotatedBeanDefinition) definition;
 
-					logger.debug(definition.getBeanClassName()
-						+ " - Scope(" + definition.getScope().toUpperCase()
-						+ ")");
-				}
+			String scopeName = null;
+			// firstly check whether bean is defined via configuration
+			if (annDef.getFactoryMethodMetadata() != null) {
+				scopeName = JsfCdiToSpring.deduceScopeName(annDef.getFactoryMethodMetadata());
+			} else {
+				// fallback to type
+				scopeName = JsfCdiToSpring.deduceScopeName(annDef.getMetadata().getAnnotationTypes());
+			}
+
+			if (scopeName != null) {
+				definition.setScope(scopeName);
+
+				logger.debug(definition.getBeanClassName()
+								 + " - Scope(" + definition.getScope().toUpperCase()
+								 + ")");
 			}
 		}
 	}

--- a/jsf-spring-boot-integration/src/test/java/org/joinfaces/annotations/JsfCdiToSpringApplicationBeanFactoryPostProcessorIT.java
+++ b/jsf-spring-boot-integration/src/test/java/org/joinfaces/annotations/JsfCdiToSpringApplicationBeanFactoryPostProcessorIT.java
@@ -17,11 +17,13 @@
 package org.joinfaces.annotations;
 
 import org.junit.Test;
-
 import org.springframework.beans.factory.annotation.AnnotatedGenericBeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigUtils;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.type.StandardAnnotationMetadata;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,41 +43,57 @@ public class JsfCdiToSpringApplicationBeanFactoryPostProcessorIT {
 
 	@Test
 	public void testViewScopedClass() {
-		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
-		beanFactory.registerBeanDefinition("viewScopedClass", new AnnotatedGenericBeanDefinition(
+		GenericApplicationContext acx = new GenericApplicationContext();
+		AnnotationConfigUtils.registerAnnotationConfigProcessors(acx);
+
+		acx.registerBeanDefinition("viewScopedClass", new AnnotatedGenericBeanDefinition(
 			new StandardAnnotationMetadata(ViewScopedClass.class)));
-		BeanFactoryPostProcessor beanFactoryPostProcessor = new JsfCdiToSpringBeanFactoryPostProcessor();
+		acx.registerBeanDefinition("scopedBeansConfiguration", new RootBeanDefinition(
+			ScopedBeansConfiguration.class));
+		acx.addBeanFactoryPostProcessor(new JsfCdiToSpringBeanFactoryPostProcessor());
+		acx.refresh();
 
-		beanFactoryPostProcessor.postProcessBeanFactory(beanFactory);
-
-		assertThat(beanFactory.getBeanDefinition("viewScopedClass").getScope())
+		assertThat(acx.getBeanDefinition("viewScopedClass").getScope())
+			.isEqualTo(JsfCdiToSpring.VIEW);
+		assertThat(acx.getBeanDefinition("viewScopedBean").getScope())
 			.isEqualTo(JsfCdiToSpring.VIEW);
 	}
 
 	@Test
 	public void testSessionScopedClass() {
-		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
-		beanFactory.registerBeanDefinition("sessionScopedClass", new AnnotatedGenericBeanDefinition(
+		GenericApplicationContext acx = new GenericApplicationContext();
+		AnnotationConfigUtils.registerAnnotationConfigProcessors(acx);
+
+		acx.registerBeanDefinition("sessionScopedClass", new AnnotatedGenericBeanDefinition(
 			new StandardAnnotationMetadata(SessionScopedClass.class)));
-		BeanFactoryPostProcessor beanFactoryPostProcessor = new JsfCdiToSpringBeanFactoryPostProcessor();
+		acx.registerBeanDefinition("scopedBeansConfiguration", new RootBeanDefinition(
+			ScopedBeansConfiguration.class));
+		acx.addBeanFactoryPostProcessor(new JsfCdiToSpringBeanFactoryPostProcessor());
+		acx.refresh();
 
-		beanFactoryPostProcessor.postProcessBeanFactory(beanFactory);
-
-		assertThat(beanFactory.getBeanDefinition("sessionScopedClass").getScope())
+		assertThat(acx.getBeanDefinition("sessionScopedClass").getScope())
+			.isEqualTo(JsfCdiToSpring.SESSION);
+		assertThat(acx.getBeanDefinition("sessionScopedBean").getScope())
 			.isEqualTo(JsfCdiToSpring.SESSION);
 	}
 
 	@Test
 	public void testNoScopedClass() {
-		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
-		beanFactory.registerBeanDefinition("noScopedClass", new AnnotatedGenericBeanDefinition(
+		GenericApplicationContext acx = new GenericApplicationContext();
+		AnnotationConfigUtils.registerAnnotationConfigProcessors(acx);
+
+		acx.registerBeanDefinition("noScopedClass", new AnnotatedGenericBeanDefinition(
 			new StandardAnnotationMetadata(NoScopedClass.class)));
-		BeanFactoryPostProcessor beanFactoryPostProcessor = new JsfCdiToSpringBeanFactoryPostProcessor();
+		acx.registerBeanDefinition("scopedBeansConfiguration", new RootBeanDefinition(
+			ScopedBeansConfiguration.class));
+		acx.addBeanFactoryPostProcessor(new JsfCdiToSpringBeanFactoryPostProcessor());
+		acx.refresh();
 
-		beanFactoryPostProcessor.postProcessBeanFactory(beanFactory);
-
-		assertThat(beanFactory.getBeanDefinition("noScopedClass").getScope())
+		assertThat(acx.getBeanDefinition("noScopedClass").getScope())
 			.isEqualTo("");
+		assertThat(acx.getBeanDefinition("noScopedBean").getScope())
+			.isEqualTo("");
+
 	}
 
 }

--- a/jsf-spring-boot-integration/src/test/java/org/joinfaces/annotations/JsfCdiToSpringTest.java
+++ b/jsf-spring-boot-integration/src/test/java/org/joinfaces/annotations/JsfCdiToSpringTest.java
@@ -18,8 +18,10 @@ package org.joinfaces.annotations;
 
 import java.util.HashSet;
 import java.util.Set;
-
+import org.joinfaces.mock.MockMethodMetadata;
 import org.junit.Test;
+import org.springframework.core.type.MethodMetadata;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsfCdiToSpringTest {
@@ -27,111 +29,151 @@ public class JsfCdiToSpringTest {
 	@Test
 	public void testCdiRequestScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
+		MethodMetadata methodMetadata = new MockMethodMetadata(javax.enterprise.context.RequestScoped.class);
 		annotationTypes.add(javax.enterprise.context.RequestScoped.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isEqualTo(JsfCdiToSpring.REQUEST);
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isEqualTo(JsfCdiToSpring.REQUEST);
 	}
 
 	@Test
 	public void testJsfRequestScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
+		MethodMetadata methodMetadata = new MockMethodMetadata(javax.faces.bean.RequestScoped.class);
 		annotationTypes.add(javax.faces.bean.RequestScoped.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isEqualTo(JsfCdiToSpring.REQUEST);
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isEqualTo(JsfCdiToSpring.REQUEST);
 	}
 
 	@Test
 	public void testCdiSessionScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
+		MethodMetadata methodMetadata = new MockMethodMetadata(javax.enterprise.context.SessionScoped.class);
 		annotationTypes.add(javax.enterprise.context.SessionScoped.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isEqualTo(JsfCdiToSpring.SESSION);
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isEqualTo(JsfCdiToSpring.SESSION);
 	}
 
 	@Test
 	public void testJsfSessionScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
+		MethodMetadata methodMetadata = new MockMethodMetadata(javax.faces.bean.SessionScoped.class);
 		annotationTypes.add(javax.faces.bean.SessionScoped.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isEqualTo(JsfCdiToSpring.SESSION);
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isEqualTo(JsfCdiToSpring.SESSION);
 	}
 
 	@Test
 	public void testCdiApplicationScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
+		MethodMetadata methodMetadata = new MockMethodMetadata(javax.enterprise.context.ApplicationScoped.class);
 		annotationTypes.add(javax.enterprise.context.ApplicationScoped.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isEqualTo(JsfCdiToSpring.SINGLETON);
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isEqualTo(JsfCdiToSpring.SINGLETON);
 	}
 
 	@Test
 	public void testJsfApplicationScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
+		MethodMetadata methodMetadata = new MockMethodMetadata(javax.faces.bean.ApplicationScoped.class);
 		annotationTypes.add(javax.faces.bean.ApplicationScoped.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isEqualTo(JsfCdiToSpring.SINGLETON);
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isEqualTo(JsfCdiToSpring.SINGLETON);
 	}
 
 	@Test
 	public void testJsfNoneScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
+		MethodMetadata methodMetadata = new MockMethodMetadata(javax.faces.bean.NoneScoped.class);
 		annotationTypes.add(javax.faces.bean.NoneScoped.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isEqualTo(JsfCdiToSpring.PROTOTYPE);
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isEqualTo(JsfCdiToSpring.PROTOTYPE);
 	}
 
 	@Test
 	public void testJsfViewViewScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
+		MethodMetadata methodMetadata = new MockMethodMetadata(javax.faces.view.ViewScoped.class);
 		annotationTypes.add(javax.faces.view.ViewScoped.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isEqualTo(JsfCdiToSpring.VIEW);
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isEqualTo(JsfCdiToSpring.VIEW);
 	}
 
 	@Test
 	public void testJsfBeanViewScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
+		MethodMetadata methodMetadata = new MockMethodMetadata(javax.faces.bean.ViewScoped.class);
 		annotationTypes.add(javax.faces.bean.ViewScoped.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isEqualTo(JsfCdiToSpring.VIEW);
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isEqualTo(JsfCdiToSpring.VIEW);
 	}
 
 	@Test
 	public void testCdiConversationScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
+		MethodMetadata methodMetadata = new MockMethodMetadata(javax.enterprise.context.ConversationScoped.class);
 		annotationTypes.add(javax.enterprise.context.ConversationScoped.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isEqualTo(JsfCdiToSpring.SESSION);
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isEqualTo(JsfCdiToSpring.SESSION);
 	}
 
 	@Test
 	public void testUnknownScopedAnnotation() {
 		Set<String> annotationTypes = new HashSet<String>();
-		annotationTypes.add("unkownScopedAnnotation");
+		MethodMetadata methodMetadata = new MockMethodMetadata(UnknownAnnotation.class);
+		annotationTypes.add(UnknownAnnotation.class.getName());
 
-		assertThat(JsfCdiToSpring.scopeName(annotationTypes))
+		assertThat(JsfCdiToSpring.deduceScopeName(annotationTypes))
+			.isNull();
+		assertThat(JsfCdiToSpring.deduceScopeName(methodMetadata))
 			.isNull();
 	}
 
 	@Test
 	public void testNull() {
-		assertThat(JsfCdiToSpring.scopeName(null))
+		assertThat(JsfCdiToSpring.deduceScopeName((Set<String>) null))
 			.isNull();
+		assertThat(JsfCdiToSpring.deduceScopeName((MethodMetadata) null))
+			.isNull();
+
 	}
 
 	@Test
 	public void testConstructor() {
 		assertThat(new JsfCdiToSpring())
 			.isNotNull();
+	}
+
+	@interface UnknownAnnotation {
+
 	}
 }

--- a/jsf-spring-boot-integration/src/test/java/org/joinfaces/annotations/ScopedBeansConfiguration.java
+++ b/jsf-spring-boot-integration/src/test/java/org/joinfaces/annotations/ScopedBeansConfiguration.java
@@ -1,0 +1,43 @@
+package org.joinfaces.annotations;
+
+import javax.enterprise.context.SessionScoped;
+import javax.faces.view.ViewScoped;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author Nurettin Yilmaz
+ */
+@Configuration
+public class ScopedBeansConfiguration {
+
+   @Bean
+   @ViewScoped
+   public ViewScopedBean viewScopedBean() {
+      return new ViewScopedBean();
+   }
+
+   @Bean
+   @SessionScoped
+   public SessionScopedBean sessionScopedBean() {
+      return new SessionScopedBean();
+   }
+
+   @Bean
+   public NoScopedBean noScopedBean() {
+      return new NoScopedBean();
+   }
+
+   static class ViewScopedBean {
+
+   }
+
+   static class SessionScopedBean {
+
+   }
+
+   static class NoScopedBean {
+
+   }
+
+}

--- a/jsf-spring-boot-integration/src/test/java/org/joinfaces/mock/MockMethodMetadata.java
+++ b/jsf-spring-boot-integration/src/test/java/org/joinfaces/mock/MockMethodMetadata.java
@@ -1,0 +1,78 @@
+package org.joinfaces.mock;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import org.springframework.core.type.MethodMetadata;
+import org.springframework.util.MultiValueMap;
+
+/**
+ * @author Nurettin Yilmaz
+ */
+public class MockMethodMetadata implements MethodMetadata {
+
+   private final Class<? extends Annotation> annotation;
+
+   public MockMethodMetadata(Class<? extends Annotation> annotation) {
+      this.annotation = annotation;
+   }
+
+   @Override
+   public String getMethodName() {
+      return null;
+   }
+
+   @Override
+   public String getDeclaringClassName() {
+      return null;
+   }
+
+   @Override
+   public String getReturnTypeName() {
+      return null;
+   }
+
+   @Override
+   public boolean isAbstract() {
+      return false;
+   }
+
+   @Override
+   public boolean isStatic() {
+      return false;
+   }
+
+   @Override
+   public boolean isFinal() {
+      return false;
+   }
+
+   @Override
+   public boolean isOverridable() {
+      return false;
+   }
+
+   @Override
+   public boolean isAnnotated(String annotationName) {
+      return annotation.getName().equals(annotationName);
+   }
+
+   @Override
+   public Map<String, Object> getAnnotationAttributes(String annotationName) {
+      return null;
+   }
+
+   @Override
+   public Map<String, Object> getAnnotationAttributes(String annotationName, boolean classValuesAsString) {
+      return null;
+   }
+
+   @Override
+   public MultiValueMap<String, Object> getAllAnnotationAttributes(String annotationName) {
+      return null;
+   }
+
+   @Override
+   public MultiValueMap<String, Object> getAllAnnotationAttributes(String annotationName, boolean classValuesAsString) {
+      return null;
+   }
+}


### PR DESCRIPTION
Referring to:

https://github.com/nyilmaz/jsf-spring-boot-starter-example/tree/failed-scanning

JSF or CDI annotated beans defined in `@Configuration` classes are not picked up.

- Changed `JsfCdiToSpringBeanFactoryPostProcessor`'s behaviour.
- Added tests.