### PR TITLE
Fixed problem accessing contextual objects in the joinfaces ViewScope…

### DIFF
--- a/jsf-spring-boot-integration/src/main/java/org/joinfaces/annotations/ViewScope.java
+++ b/jsf-spring-boot-integration/src/main/java/org/joinfaces/annotations/ViewScope.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.joinfaces.annotations;
 
 import java.util.Map;
@@ -22,45 +21,48 @@ import javax.faces.context.FacesContext;
 
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.config.Scope;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
 
 /**
  * Implementation of view scope.
+ *
  * @author Marcelo Fernandes
  */
 public class ViewScope implements Scope {
 
-	@Override
-	public Object get(String name, ObjectFactory objectFactory) {
-		Map<String, Object> viewMap = FacesContext.getCurrentInstance().getViewRoot().getViewMap();
+    @Override
+    public Object get(String name, ObjectFactory objectFactory) {
+        Map<String, Object> viewMap = FacesContext.getCurrentInstance().getViewRoot().getViewMap();
 
-		if (viewMap.containsKey(name)) {
-			return viewMap.get(name);
-		}
-		else {
-			Object object = objectFactory.getObject();
-			viewMap.put(name, object);
+        if (viewMap.containsKey(name)) {
+            return viewMap.get(name);
+        } else {
+            Object object = objectFactory.getObject();
+            viewMap.put(name, object);
 
-			return object;
-		}
-	}
+            return object;
+        }
+    }
 
-	@Override
-	public Object remove(String name) {
-		return FacesContext.getCurrentInstance().getViewRoot().getViewMap().remove(name);
-	}
+    @Override
+    public Object remove(String name) {
+        return FacesContext.getCurrentInstance().getViewRoot().getViewMap().remove(name);
+    }
 
-	@Override
-	public String getConversationId() {
-		return null;
-	}
+    @Override
+    public String getConversationId() {
+        return null;
+    }
 
-	@Override
-	public void registerDestructionCallback(String name, Runnable callback) {
-		//Not supported
-	}
+    @Override
+    public void registerDestructionCallback(String name, Runnable callback) {
+        //Not supported
+    }
 
-	@Override
-	public Object resolveContextualObject(String key) {
-		return null;
-	}
+    @Override
+    public Object resolveContextualObject(String key) {
+        RequestAttributes attributes = RequestContextHolder.currentRequestAttributes();
+        return attributes.resolveReference(key);
+    }
 }

--- a/jsf-spring-boot-integration/src/main/java/org/joinfaces/annotations/ViewScope.java
+++ b/jsf-spring-boot-integration/src/main/java/org/joinfaces/annotations/ViewScope.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.joinfaces.annotations;
 
 import java.util.Map;
@@ -26,43 +27,43 @@ import org.springframework.web.context.request.RequestContextHolder;
 
 /**
  * Implementation of view scope.
- *
  * @author Marcelo Fernandes
  */
 public class ViewScope implements Scope {
 
-    @Override
-    public Object get(String name, ObjectFactory objectFactory) {
-        Map<String, Object> viewMap = FacesContext.getCurrentInstance().getViewRoot().getViewMap();
+	@Override
+	public Object get(String name, ObjectFactory objectFactory) {
+		Map<String, Object> viewMap = FacesContext.getCurrentInstance().getViewRoot().getViewMap();
 
-        if (viewMap.containsKey(name)) {
-            return viewMap.get(name);
-        } else {
-            Object object = objectFactory.getObject();
-            viewMap.put(name, object);
+		if (viewMap.containsKey(name)) {
+			return viewMap.get(name);
+		}
+		else {
+			Object object = objectFactory.getObject();
+			viewMap.put(name, object);
 
-            return object;
-        }
-    }
+			return object;
+		}
+	}
 
-    @Override
-    public Object remove(String name) {
-        return FacesContext.getCurrentInstance().getViewRoot().getViewMap().remove(name);
-    }
+	@Override
+	public Object remove(String name) {
+		return FacesContext.getCurrentInstance().getViewRoot().getViewMap().remove(name);
+	}
 
-    @Override
-    public String getConversationId() {
-        return null;
-    }
+	@Override
+	public String getConversationId() {
+		return null;
+	}
 
-    @Override
-    public void registerDestructionCallback(String name, Runnable callback) {
-        //Not supported
-    }
+	@Override
+	public void registerDestructionCallback(String name, Runnable callback) {
+		//Not supported
+	}
 
-    @Override
-    public Object resolveContextualObject(String key) {
-        RequestAttributes attributes = RequestContextHolder.currentRequestAttributes();
-        return attributes.resolveReference(key);
-    }
+	@Override
+	public Object resolveContextualObject(String key) {
+		RequestAttributes attributes = RequestContextHolder.currentRequestAttributes();
+		return attributes.resolveReference(key);
+	}
 }


### PR DESCRIPTION
… integration class.

Modified the resolveContextualObject allowing the use of EL with context objects in ViewScoped beans.

With this addition we could use the request object to inject a request parameter inside a ViewScoped bean.

``@Value("#{request.getParameter('filter')}") String filter``