### PR TITLE
Fix the disableUnicodeEscaping property

### DIFF
--- a/jsf-spring-boot-autoconfigure/src/main/java/org/joinfaces/mojarra/MojarraProperties.java
+++ b/jsf-spring-boot-autoconfigure/src/main/java/org/joinfaces/mojarra/MojarraProperties.java
@@ -165,7 +165,7 @@ public class MojarraProperties {
 	 * as HTML entities and any characters above that range will be written as
 	 * decimal references.
 	 */
-	private Boolean disableUnicodeEscaping;
+	private String disableUnicodeEscaping;
 
 	/**
 	 * If true, then component ID uniqueness won't be checked if ProjectStage is

--- a/jsf-spring-boot-autoconfigure/src/main/java/org/joinfaces/mojarra/MojarraServletContextConfigurer.java
+++ b/jsf-spring-boot-autoconfigure/src/main/java/org/joinfaces/mojarra/MojarraServletContextConfigurer.java
@@ -55,7 +55,7 @@ public class MojarraServletContextConfigurer extends ServletContextConfigurer {
 		setInitParameterBoolean("allowTextChildren", this.mojarraProperties.getAllowTextChildren());
 		setInitParameterBoolean("autoCompleteOffOnViewState", this.mojarraProperties.getAutoCompleteOffOnViewState());
 		setInitParameterBoolean("compressJavaScript", this.mojarraProperties.getCompressJavaScript());
-		setInitParameterBoolean("disableUnicodeEscaping", this.mojarraProperties.getDisableUnicodeEscaping());
+		setInitParameterString("disableUnicodeEscaping", this.mojarraProperties.getDisableUnicodeEscaping());
 		setInitParameterBoolean("disableIdUniquenessCheck", this.mojarraProperties.getDisableIdUniquenessCheck());
 		setInitParameterBoolean("enabledJSStyleHiding", this.mojarraProperties.getEnabledJSStyleHiding());
 		setInitParameterBoolean("enableScriptsInAttributeValues", this.mojarraProperties.getEnableScriptsInAttributeValues());

--- a/jsf-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/jsf-spring-boot-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,4 +1,10 @@
 {
+  "properties": [
+    {
+      "name": "jsf.mojarra.disable-unicode-escaping",
+      "defaultValue": "false"
+    }
+  ],
   "hints": [
     {
       "name": "jsf.state-saving-method",
@@ -38,6 +44,23 @@
             "target": "javax.faces.view.facelets.ResourceResolver",
             "concrete": true
           }
+        }
+      ]
+    },
+    {
+      "name": "jsf.mojarra.disable-unicode-escaping",
+      "values": [
+        {
+          "value": "auto",
+          "description": "The response encoding will be checked: If the encoding is of the UTF family of encodings no unicode or html entity encoding will occur, however, if the response stream encoding is ISO-8859-1 then the ISO characters above a certain range will be encoded as HTML entities and any characters above that range will be written as decimal references."
+        },
+        {
+          "value": "true",
+          "description": "No escaping will occur assuming that the response encoding can properly handle all characters."
+        },
+        {
+          "value": "false",
+          "description": "Any characters above a certain range will be escaped as either an HTML entity or a decimal reference."
         }
       ]
     },

--- a/jsf-spring-boot-autoconfigure/src/test/java/org/joinfaces/mojarra/MojarraPropertiesIT.java
+++ b/jsf-spring-boot-autoconfigure/src/test/java/org/joinfaces/mojarra/MojarraPropertiesIT.java
@@ -113,7 +113,7 @@ public class MojarraPropertiesIT {
 	@Test
 	public void testDisableUnicodeEscaping() {
 		assertThat(this.mojarraProperties.getDisableUnicodeEscaping())
-			.isTrue();
+			.isEqualTo("true");
 	}
 
 	@Test


### PR DESCRIPTION
The property can hold three different values: `true`, `false` and `auto`.
So `Boolean` is inappropriate.