### PR TITLE
Ignore trivial methods in coverage calculation

### DIFF
--- a/jsf-spring-boot-parent/pom.xml
+++ b/jsf-spring-boot-parent/pom.xml
@@ -33,7 +33,7 @@
         <bootsfaces.version>1.0.2</bootsfaces.version>
         <angularfaces.version>2.1.12</angularfaces.version>
 
-        <butterfaces.version>2.1.18</butterfaces.version>
+        <butterfaces.version>2.1.19</butterfaces.version>
 
         <richfaces.version>4.5.17.Final</richfaces.version>
                                                                         


### PR DESCRIPTION
trivial methods are simple getters, setters and constructors just setting fields and/or calling super()