### PR TITLE
Prevent two application contexts in war deployment

### DIFF
--- a/jsf-jetty-spring-boot-autoconfigure/src/main/java/org/joinfaces/jetty/JettySpringBootAutoConfiguration.java
+++ b/jsf-jetty-spring-boot-autoconfigure/src/main/java/org/joinfaces/jetty/JettySpringBootAutoConfiguration.java
@@ -22,7 +22,6 @@ import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletCont
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
 import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -36,7 +35,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties({JettyProperties.class})
 @ConditionalOnClass(name = "org.eclipse.jetty.server.Server")
-public class JettySpringBootAutoConfiguration extends SpringBootServletInitializer implements EmbeddedServletContainerCustomizer {
+public class JettySpringBootAutoConfiguration implements EmbeddedServletContainerCustomizer {
 
 	@Autowired
 	private JettyProperties jettyProperties;

--- a/jsf-tomcat-spring-boot-autoconfigure/src/main/java/org/joinfaces/tomcat/TomcatSpringBootAutoConfiguration.java
+++ b/jsf-tomcat-spring-boot-autoconfigure/src/main/java/org/joinfaces/tomcat/TomcatSpringBootAutoConfiguration.java
@@ -20,7 +20,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletContainer;
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
 import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -32,8 +31,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @ConditionalOnClass(name = "org.apache.catalina.Context")
 @Configuration
-public class TomcatSpringBootAutoConfiguration
-	extends SpringBootServletInitializer implements EmbeddedServletContainerCustomizer {
+public class TomcatSpringBootAutoConfiguration implements EmbeddedServletContainerCustomizer {
 
 	private JsfTomcatContextCustomizer customizer = new JsfTomcatContextCustomizer();
 

--- a/jsf-undertow-spring-boot-autoconfigure/src/main/java/org/joinfaces/undertow/UndertowSpringBootAutoConfiguration.java
+++ b/jsf-undertow-spring-boot-autoconfigure/src/main/java/org/joinfaces/undertow/UndertowSpringBootAutoConfiguration.java
@@ -22,7 +22,6 @@ import org.springframework.boot.context.embedded.ConfigurableEmbeddedServletCont
 import org.springframework.boot.context.embedded.EmbeddedServletContainerCustomizer;
 import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -33,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties({UndertowProperties.class})
 @ConditionalOnClass(name = "io.undertow.Undertow")
-public class UndertowSpringBootAutoConfiguration extends SpringBootServletInitializer implements EmbeddedServletContainerCustomizer {
+public class UndertowSpringBootAutoConfiguration implements EmbeddedServletContainerCustomizer {
 
 	@Autowired
 	private UndertowProperties undertowProperties;


### PR DESCRIPTION
The SpringBootServletInitializer should be provided by the application and not by joinfaces.
See https://github.com/joinfaces/joinfaces/issues/77#issuecomment-299669402