### PR TITLE
Register beans of type CustomScopeAnnotationConfigurer with this conc…

### DIFF
--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/integration/CdiScopeAnnotationsAutoConfiguration.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/integration/CdiScopeAnnotationsAutoConfiguration.java
@@ -44,7 +44,7 @@ public class CdiScopeAnnotationsAutoConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(value = "jsf.scope-configurer.cdi.enabled", havingValue = "true", matchIfMissing = true)
-	public static BeanFactoryPostProcessor cdiScopeAnnotationsConfigurer(Environment environment) {
+	public static CustomScopeAnnotationConfigurer cdiScopeAnnotationsConfigurer(Environment environment) {
 		CustomScopeAnnotationConfigurer scopeAnnotationConfigurer = new CustomScopeAnnotationConfigurer();
 
 		scopeAnnotationConfigurer.setOrder(environment.getProperty("jsf.scope-configurer.cdi.order", Integer.class, Ordered.LOWEST_PRECEDENCE));

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/integration/CdiScopeAnnotationsAutoConfiguration.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/integration/CdiScopeAnnotationsAutoConfiguration.java
@@ -22,7 +22,6 @@ import javax.enterprise.context.ConversationScoped;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.context.SessionScoped;
 
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/integration/JsfScopeAnnotationsAutoConfiguration.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/integration/JsfScopeAnnotationsAutoConfiguration.java
@@ -21,7 +21,6 @@ import javax.faces.bean.NoneScoped;
 import javax.faces.bean.RequestScoped;
 import javax.faces.bean.SessionScoped;
 
-import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/integration/JsfScopeAnnotationsAutoConfiguration.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/integration/JsfScopeAnnotationsAutoConfiguration.java
@@ -44,7 +44,7 @@ public class JsfScopeAnnotationsAutoConfiguration {
 
 	@Bean
 	@ConditionalOnProperty(value = "jsf.scope-configurer.jsf.enabled", havingValue = "true", matchIfMissing = true)
-	public static BeanFactoryPostProcessor jsfScopeAnnotationsConfigurer(Environment environment) {
+	public static CustomScopeAnnotationConfigurer jsfScopeAnnotationsConfigurer(Environment environment) {
 		CustomScopeAnnotationConfigurer scopeAnnotationConfigurer = new CustomScopeAnnotationConfigurer();
 
 		scopeAnnotationConfigurer.setOrder(environment.getProperty("jsf.scope-configurer.jsf.order", Integer.class, Ordered.LOWEST_PRECEDENCE));


### PR DESCRIPTION
…rete type instead of BeanFactoryPostProcessor, allowing spring to sort the beans based on the Ordered interface (implemented by CustomScopeAnnotationConfigurer, not BeanFactoryPostProcessor).

See [PostProcessorRegistrationDelegate.invokeBeanFactoryPostProcessors](https://github.com/spring-projects/spring-framework/blob/40127bd9adde6f44963c47edd3ed57c623980c26/spring-context/src/main/java/org/springframework/context/support/PostProcessorRegistrationDelegate.java#L154)

