### PR TITLE
Update Spring Boot to 1.5.10

### DIFF
--- a/jsf-spring-boot-parent/pom.xml
+++ b/jsf-spring-boot-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.7.RELEASE</version>
+        <version>1.5.10.RELEASE</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 


### PR DESCRIPTION
https://spring.io/blog/2018/01/31/spring-boot-1-5-10-available-now