### PR TITLE
Upgrade Spring Boot to 2.0.0.RELEASE

### DIFF
--- a/joinfaces-dependencies/pom.xml
+++ b/joinfaces-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.0.0.RC1</version>
+        <version>2.0.0.RC2</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     

--- a/joinfaces-dependencies/pom.xml
+++ b/joinfaces-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.0.0.RC2</version>
+        <version>2.0.0.RELEASE</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     


### PR DESCRIPTION
@larsgrefer , `org.joinfaces.autoconfigure.omnifaces.OmnifacesProperties.exceptionTypesToUnwrap` test failed after upgrading spring boot to 2.0.0.RC2.

Could you take o look please?