### PR TITLE
enable tomcat to read BOOT-INF/classes/META-INF/resources

### DIFF
--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/tomcat/JsfTomcatApplicationListener.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/tomcat/JsfTomcatApplicationListener.java
@@ -149,6 +149,7 @@ public class JsfTomcatApplicationListener implements ApplicationListener<Applica
 					// add main resource
 					case UBER_JAR: try {
 							addMainJarResourceSet(resources);
+							addClasspathResourceSets(resources);
 						}
 						catch (URISyntaxException ex) {
 							log.error(ex.getMessage());
@@ -177,9 +178,13 @@ public class JsfTomcatApplicationListener implements ApplicationListener<Applica
 		String webAppMount = "/";
 		String archivePath = null;
 		String internalPath = "/META-INF/resources";
+		String bootInfPath = "/BOOT-INF/classes";
 
 		resources.createWebResourceSet(WebResourceRoot.ResourceSetType.POST,
 			webAppMount, base(mainFile(resources)), archivePath, internalPath);
+		System.out.println("ADICIONOU2 : '" + base(mainFile(resources)));
+		resources.createWebResourceSet(WebResourceRoot.ResourceSetType.POST,
+			webAppMount, base(mainFile(resources)), archivePath, bootInfPath + internalPath);
 	}
 
 	private void addClasspathResourceSets(WebResourceRoot resources) throws URISyntaxException {

--- a/joinfaces-autoconfigure/src/test/java/org/joinfaces/autoconfigure/tomcat/JsfTomcatApplicationListenerIT.java
+++ b/joinfaces-autoconfigure/src/test/java/org/joinfaces/autoconfigure/tomcat/JsfTomcatApplicationListenerIT.java
@@ -166,7 +166,7 @@ public class JsfTomcatApplicationListenerIT {
 		callApplicationEvent(contextMock);
 
 		assertThat(contextMock.getWebResourceRoot().getCreateWebResourceSetCalls())
-			.isEqualTo(1);
+			.isEqualTo(2);
 	}
 
 	@Test
@@ -186,7 +186,7 @@ public class JsfTomcatApplicationListenerIT {
 		callApplicationEvent(contextMock);
 
 		assertThat(contextMock.getWebResourceRoot().getCreateWebResourceSetCalls())
-			.isEqualTo(1);
+			.isEqualTo(2);
 	}
 
 	@Test
@@ -206,7 +206,7 @@ public class JsfTomcatApplicationListenerIT {
 		callApplicationEvent(contextMock);
 
 		assertThat(contextMock.getWebResourceRoot().getCreateWebResourceSetCalls())
-			.isEqualTo(1);
+			.isEqualTo(2);
 	}
 
 	@Test


### PR DESCRIPTION
Apparently, [META-INF/resources are stored in one new directory by gradle spring boot plugin](https://stackoverflow.com/questions/49215128/spring-boot-generates-different-ubber-jar-in-2-0-0-release-with-gradle-and-maven).

In other to accommodate gradle and maven, this PR is proposed.