### PR TITLE
add cdi-api dependency to adminfaces-spring-boot-starter

### DIFF
--- a/joinfaces-starters/adminfaces-spring-boot-starter/pom.xml
+++ b/joinfaces-starters/adminfaces-spring-boot-starter/pom.xml
@@ -42,5 +42,9 @@
             <groupId>javax.ejb</groupId>
             <artifactId>javax.ejb-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
`adminfaces-spring-boot-starter` pulls `admin-template` and `admin-theme` dependencies. `admin-template` uses cdi classes. So, this starter should pull `cdi-api`.
More discussion in #503.