### PR TITLE
Make spring-mvc dependency optional

### DIFF
--- a/joinfaces-starters/jsf-spring-boot-starter/pom.xml
+++ b/joinfaces-starters/jsf-spring-boot-starter/pom.xml
@@ -19,13 +19,11 @@
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-starter-tomcat</artifactId>                    
-                </exclusion>
-            </exclusions>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
_Spring MVC_ is not required for JSF applications on _Spring Boot_ so this PR removes the dependency on `spring-boot-starter-web`.

Joinfaces users which depend on `spring-mvc`, `spring-boot-starter-web` or `spring-boot-starter-json` should add a direct dependeny to those modules.