### PR TITLE
admin-template classes need spring-webmvc

### DIFF
--- a/joinfaces-starters/adminfaces-spring-boot-starter/pom.xml
+++ b/joinfaces-starters/adminfaces-spring-boot-starter/pom.xml
@@ -46,5 +46,9 @@
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>		
     </dependencies>
 </project>


### PR DESCRIPTION
I got the following error if spring-webmvc is not present at classpath:

```
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'scopedTarget.logonMB': Scope 'session' is not active for the current thread; consider defining a scoped proxy for this bean if you intend to refer to it from a singleton; nested exception is java.lang.IllegalStateException: No thread-bound request found: Are you referring to request attributes outside of an actual web request, or processing a request outside of the originally receiving thread? If you are actually operating within a web request and still receive this message, your code is probably running outside of DispatcherServlet/DispatcherPortlet: In this case, use RequestContextListener or RequestContextFilter to expose the current request.
```