### PR TITLE
Mojarra defaultResourceMaxAge configuration property as long

### DIFF
--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/mojarra/MojarraProperties.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/mojarra/MojarraProperties.java
@@ -268,7 +268,7 @@ public class MojarraProperties implements ServletContextInitParameterProperties 
 	 * the default value of 604800000 is 7 days).
 	 */
 	@ServletContextInitParameter(PREFIX + "defaultResourceMaxAge")
-	private Integer defaultResourceMaxAge;
+	private Long defaultResourceMaxAge;
 
 	/**
 	 * See issue 3684 for details.


### PR DESCRIPTION
Currently the max value of `joinfaces.mojarra.default-resource-max-age` is limited by type to `Integer.MAX_VALUE` in milliseconds (~ 24.85 days). 
Changed to `Long` to allow longer values, e.g. `2592000000` (30 days)