### PR TITLE
Do not reset session attributes when session is invalidated

### DIFF
--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/session/SpringSessionFixFilter.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/session/SpringSessionFixFilter.java
@@ -55,7 +55,7 @@ public class SpringSessionFixFilter extends OncePerRequestFilter {
 
 		HttpSession session = request.getSession(false);
 
-		if (session != null && wrappedRequest.sessionWrapper != null) {
+		if (session != null && wrappedRequest.sessionWrapper != null && !wrappedRequest.sessionWrapper.invalidated) {
 			reSetAttributes(wrappedRequest.sessionWrapper);
 		}
 
@@ -131,6 +131,7 @@ public class SpringSessionFixFilter extends OncePerRequestFilter {
 	@RequiredArgsConstructor
 	static class SessionWrapper implements HttpSession {
 		private final HttpSession delegate;
+		private boolean invalidated = false;
 
 		@NonNull
 		@Getter
@@ -223,6 +224,7 @@ public class SpringSessionFixFilter extends OncePerRequestFilter {
 		@Override
 		public void invalidate() {
 			this.delegate.invalidate();
+			this.invalidated = true;
 		}
 
 		@Override


### PR DESCRIPTION
If the session has been invalidated, the method reSetAttributes of SpringSessionFixFilter fails.

So, with this PR, reSetAttributes is called only with valid sessions.