### PR TITLE
4.5.x: Bump jakarta faces to maintenance release 2.3.18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ allprojects {
         dependencies {
             dependency 'jakarta.faces:jakarta.faces-api:2.3.2'
 
-            dependency 'org.glassfish:jakarta.faces:2.3.17'
+            dependency 'org.glassfish:jakarta.faces:2.3.18'
 
             dependencySet('org.apache.myfaces.core:2.3.9') {
                 entry "myfaces-api"


### PR DESCRIPTION
I maintain a project on 4.5.x.

I submitted a patch to mojarra, which is in release 2.3.18, so I would appreciate if this could also be upgraded on 4.5.x.