### PR TITLE
Update Springboot version to 3.0.0

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -6,7 +6,7 @@ repositories {
     maven { url 'https://repo.spring.io/snapshot' }
 }
 
-def springBootVersion = "3.0.0-RC2"
+def springBootVersion = "3.0.0"
 
 dependencies {
     api "org.springframework.boot:spring-boot-gradle-plugin:$springBootVersion"


### PR DESCRIPTION
Springboot 3.0.0 Released OFFICIAL: https://github.com/spring-projects/spring-boot/releases/tag/v3.0.0