### PR TITLE
Improved documentation and replaced old javax annotation by jakarta.

### DIFF
--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/JoinfacesApplicationAnalyzer.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/JoinfacesApplicationAnalyzer.java
@@ -51,7 +51,7 @@ public class JoinfacesApplicationAnalyzer implements ApplicationListener<Applica
 
 		for (String managedBeanName : managedBeanNames) {
 			log.warn(
-					"The spring bean '{}' of type '{}' is also annotated with '@javax.faces.bean.ManagedBean'. This may lead to unexpected behaviour.",
+					"The spring bean '{}' of type '{}' is also annotated with '@jakarta.faces.bean.ManagedBean'. This may lead to unexpected behaviour.",
 					managedBeanName,
 					applicationContext.getType(managedBeanName).getName()
 			);

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/faces/JakartaFaces3Properties.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/faces/JakartaFaces3Properties.java
@@ -142,7 +142,7 @@ public class JakartaFaces3Properties implements ServletContextInitParameterPrope
 	private Integer faceletsBufferSize;
 
 	/**
-	 * TagDecorator implementations. See javadoc for javax.faces.view.facelets.TagDecorator.
+	 * TagDecorator implementations. See javadoc for jakarta.faces.view.facelets.TagDecorator.
 	 */
 	@ServletContextInitParameter(value = ViewHandler.FACELETS_DECORATORS_PARAM_NAME, listSeparator = ";")
 	private List<Class<? extends TagDecorator>> faceletsDecorators;
@@ -155,7 +155,7 @@ public class JakartaFaces3Properties implements ServletContextInitParameterPrope
 	private Integer faceletsRefreshPeriod;
 
 	/**
-	 * An implementation of javax.faces.view.facelets.ResourceResolver.
+	 * An implementation of jakarta.faces.view.facelets.ResourceResolver.
 	 * See javadoc for details.
 	 */
 	@Deprecated(forRemoval = true, since = "5.0.0")
@@ -249,7 +249,7 @@ public class JakartaFaces3Properties implements ServletContextInitParameterPrope
 	/**
 	 * If this param is set, and calling toLowerCase().equals("true") on a
 	 * String representation of its value returns true, and the
-	 * javax.faces.STATE_SAVING_METHOD is set to "server" (as indicated below),
+	 * jakarta.faces.STATE_SAVING_METHOD is set to "server" (as indicated below),
 	 * the server state must be guaranteed to be Serializable such that the
 	 * aggregate state implements java.io.Serializable. The intent of this
 	 * parameter is to ensure that the act of writing out the state to an

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/javaxfaces/JsfBeansAnnotationPostProcessor.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/javaxfaces/JsfBeansAnnotationPostProcessor.java
@@ -49,7 +49,7 @@ import org.springframework.util.ReflectionUtils;
  * This {@link BeanPostProcessor} injects JSF artifacts which use a custom qualifier annotation.
  *
  * @author Lars Grefer
- * @see javax.faces.annotation
+ * @see jakarta.faces.annotation
  */
 public class JsfBeansAnnotationPostProcessor implements BeanPostProcessor {
 

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/mojarra/MojarraProperties.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/mojarra/MojarraProperties.java
@@ -50,7 +50,7 @@ public class MojarraProperties implements ServletContextInitParameterProperties 
 	 * Maximum time, in seconds, that client state will be considered valid by
 	 * the default StateManager/ResponseStateManager implementations. If the
 	 * time between requests exceeds the configured time, a
-	 * javax.faces.application.ViewExpiredException. will be thrown. It is
+	 * jakarta.faces.application.ViewExpiredException. will be thrown. It is
 	 * important to note that if this feature is enabled, and client requests
 	 * are recieved with view state produced from a previous version, the
 	 * ViewExpiredException will be thrown immediately.
@@ -133,7 +133,7 @@ public class MojarraProperties implements ServletContextInitParameterProperties 
 	 * being stored in the session. This may be desirable for applications that
 	 * may have issues with view state being sensitive to model changes after
 	 * state saving which are reflected back in view state. This has since JSF
-	 * 2.2 been replaced by javax.faces.SERIALIZE_SERVER_STATE.
+	 * 2.2 been replaced by jakarta.faces.SERIALIZE_SERVER_STATE.
 	 */
 	@ServletContextInitParameter(PREFIX + "serializeServerState")
 	private Boolean serializeServerState;
@@ -221,11 +221,11 @@ public class MojarraProperties implements ServletContextInitParameterProperties 
 
 	/**
 	 * If true, the view state hidden field will be rendered with both the id
-	 * and name attributes having the value of "javax.faces.ViewState". This is
+	 * and name attributes having the value of "jakarta.faces.ViewState". This is
 	 * what the spec requires, however, if there are multiple forms within a
 	 * view and the response content-type is XHTML, the result will be XHTML
 	 * that will fail validation due to multiple ID attributes with the same
-	 * value: javax.faces.ViewState. Setting this parameter to false will result
+	 * value: jakarta.faces.ViewState. Setting this parameter to false will result
 	 * in the ID attribute not being rendered. Keep in mind however, that doing
 	 * this may break integration with AJAX frameworks that get the state field
 	 * via ID. See issue 433 for details.
@@ -247,7 +247,7 @@ public class MojarraProperties implements ServletContextInitParameterProperties 
 	 * This parameter specifies the size, in bytes, of the buffer that is used
 	 * to write all generated JSP content excluding state. Note that this is
 	 * ignored when Facelets is used. For Facelets, use
-	 * javax.faces.FACELETS_BUFFER_SIZE instead.
+	 * jakarta.faces.FACELETS_BUFFER_SIZE instead.
 	 */
 	@DataSizeUnit(DataUnit.BYTES)
 	@ServletContextInitParameter(PREFIX + "responseBufferSize")
@@ -298,7 +298,7 @@ public class MojarraProperties implements ServletContextInitParameterProperties 
 	private Boolean enableMissingResourceLibraryDetection;
 
 	/**
-	 * When javax.faces.PROJECT_STATE is Production, UnitTest, or SystemTest
+	 * When jakarta.faces.PROJECT_STATE is Production, UnitTest, or SystemTest
 	 * resource paths will be cached to reduce the overhead of resource path
 	 * compuation. By default, updates (i.e. new files, new directories, new
 	 * versions, etc.) will be checked for every 5 minutes. If a change is
@@ -329,7 +329,7 @@ public class MojarraProperties implements ServletContextInitParameterProperties 
 
 	/**
 	 * The value of this context init parameter is a whitespace separated list
-	 * of values that control which class packages are scanned for javax.faces
+	 * of values that control which class packages are scanned for jakarta.faces
 	 * annotations. To restrict which jars/packages are scanned, use the
 	 * following entry format: jar:'jar name':'comma separated list of packages'
 	 * So an example would be: jar:a.jar:com.acme.package1,com.acme.package2.

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/myfaces/MyFacesProperties.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/myfaces/MyFacesProperties.java
@@ -159,7 +159,7 @@ public class MyFacesProperties implements ServletContextInitParameterProperties 
 
 	/**
 	 * Define an alternate class name that will be used to initialize MyFaces,
-	 * instead the default javax.
+	 * instead the default jakarta.
 	 */
 	@ServletContextInitParameter(PREFFIX + "DELEGATE_FACES_SERVLET")
 	private Class<?> delegateFacesServlet;
@@ -246,8 +246,8 @@ public class MyFacesProperties implements ServletContextInitParameterProperties 
 	private Integer componentUniqueIdsCacheSize;
 
 	/**
-	 * If set false, myfaces won't support JSP and javax.faces.el. JSP are
-	 * deprecated in " + "JSF 2.X, javax.faces.el in in JSF 1.2. Default value
+	 * If set false, myfaces won't support JSP and jakarta.faces.el. JSP are
+	 * deprecated in " + "JSF 2.X, jakarta.faces.el in in JSF 1.2. Default value
 	 * is true.
 	 */
 	@ServletContextInitParameter(PREFFIX + "SUPPORT_JSP_AND_FACES_EL")

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/scopemapping/CdiScopeAnnotationsAutoConfiguration.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/scopemapping/CdiScopeAnnotationsAutoConfiguration.java
@@ -32,7 +32,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto configuration}
- * for {@code javax.enterprise.context.*Scoped} annotations support.
+ * for {@code jakarta.enterprise.context.*Scoped} annotations support.
  *
  * @author Diego Diez
  * @author Lars Grefer

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/scopemapping/Jsf3ScopeAnnotationsAutoConfiguration.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/scopemapping/Jsf3ScopeAnnotationsAutoConfiguration.java
@@ -30,7 +30,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 /**
  * {@link org.springframework.boot.autoconfigure.EnableAutoConfiguration Auto configuration}
- * for {@code javax.faces.bean.*Scoped} annotations support.
+ * for {@code jakarta.faces.bean.*Scoped} annotations support.
  *
  * @author Diego Diez
  * @author Lars Grefer

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/scopemapping/ScopeConfigurerProperties.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/scopemapping/ScopeConfigurerProperties.java
@@ -43,7 +43,7 @@ public class ScopeConfigurerProperties {
 	private final ScopeConfigurer faces = new ScopeConfigurer();
 
 	/**
-	 * Support for CDI @javax.enterprise.context.xxxScoped annotations.
+	 * Support for CDI @jakarta.enterprise.context.xxxScoped annotations.
 	 */
 	@NestedConfigurationProperty
 	private final ScopeConfigurer cdi = new ScopeConfigurer();

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/servlet/initparams/ServletContextInitParameter.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/servlet/initparams/ServletContextInitParameter.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a field of a {@link org.springframework.boot.context.properties.ConfigurationProperties Properties class}
- * as {@link javax.servlet.ServletContext#setInitParameter(String, String) servlet context init parameter}.
+ * as {@link jakarta.servlet.ServletContext#setInitParameter(String, String) servlet context init parameter}.
  *
  * @author Lars Grefer
  * @see InitParameterServletContextConfigurer

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/servlet/initparams/ServletContextInitParameterProperties.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/servlet/initparams/ServletContextInitParameterProperties.java
@@ -20,7 +20,7 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 /**
  * Marker interface for all {@link org.springframework.boot.context.properties.ConfigurationProperties configuration properties}
- * which contain {@link ServletContextInitParameter init parameters} to be set on a {@link javax.servlet.ServletContext servlet context}.
+ * which contain {@link ServletContextInitParameter init parameters} to be set on a {@link jakarta.servlet.ServletContext servlet context}.
  * <p>
  * Classes implementing this interface should
  * <ul>

--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/servlet/initparams/ServletContextInitParameterPropertiesAutoConfiguration.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/servlet/initparams/ServletContextInitParameterPropertiesAutoConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Bean;
 
 /**
  * Common base class for all auto-configuration classes which provide properties
- * as {@link javax.servlet.ServletContext} init parameters.
+ * as {@link jakarta.servlet.ServletContext} init parameters.
  *
  * @author Lars Grefer
  */

--- a/src/docs/asciidoc/_features.adoc
+++ b/src/docs/asciidoc/_features.adoc
@@ -95,7 +95,7 @@ JSF implementations and JSF component libraries are usually configured using ser
 [source,xml]
 ----
 <context-param>
-    <param-name>javax.faces.PROJECT_STAGE</param-name>
+    <param-name>jakarta.faces.PROJECT_STAGE</param-name>
     <param-value>Development</param-value>
 </context-param>
 <context-param>
@@ -125,7 +125,7 @@ If you need a to set a parameter which isn't specially handled by JoinFaces, you
 
 [source,properties,subs="+quotes"]
 ----
-server.servlet.context-parameters._javax.faces.PROJECT_STAGE_=Development
+server.servlet.context-parameters._jakarta.faces.PROJECT_STAGE_=Development
 server.servlet.context-parameters._primefaces.THEME_=omega
 ----
 ====
@@ -183,25 +183,25 @@ The following annotations can be used to define the scope of Spring beans:
 
 ==== New JSF Scope annotation (JSF >= 2.2)
 
-- https://docs.oracle.com/javaee/7/api/javax/faces/view/ViewScoped.html[`@javax.faces.view.ViewScoped`] (mapped to Joinfaces' `view` scope)
+- https://docs.oracle.com/javaee/7/api/javax/faces/view/ViewScoped.html[`@jakarta.faces.view.ViewScoped`] (mapped to Joinfaces' `view` scope)
 
 ==== Old JSF Scope annotations (JSF <= 2.1)
 
 CAUTION: The following annotations are only supported for backwards compatibility.
 New applications should only use the annotations above.
 
-- https://docs.oracle.com/javaee/7/api/javax/faces/bean/ApplicationScoped.html[`@javax.faces.bean.ApplicationScoped`] (mapped to Spring's `application` scope)
-- https://docs.oracle.com/javaee/7/api/javax/faces/bean/NoneScoped.html[`@javax.faces.bean.NoneScoped`] (mapped to Spring's `prototype` scope)
-- https://docs.oracle.com/javaee/7/api/javax/faces/bean/RequestScoped.html[`@javax.faces.bean.RequestScoped`] (mapped to Spring's `request` scope)
-- https://docs.oracle.com/javaee/7/api/javax/faces/bean/SessionScoped.html[`@javax.faces.bean.SessionScoped`] (mapped to Spring's `session` scope)
-- https://docs.oracle.com/javaee/7/api/javax/faces/bean/ViewScoped.html[`@javax.faces.bean.ViewScoped`] (mapped to Joinfaces' `view` scope)
+- https://docs.oracle.com/javaee/7/api/javax/faces/bean/ApplicationScoped.html[`@jakarta.faces.bean.ApplicationScoped`] (mapped to Spring's `application` scope)
+- https://docs.oracle.com/javaee/7/api/javax/faces/bean/NoneScoped.html[`@jakarta.faces.bean.NoneScoped`] (mapped to Spring's `prototype` scope)
+- https://docs.oracle.com/javaee/7/api/javax/faces/bean/RequestScoped.html[`@jakarta.faces.bean.RequestScoped`] (mapped to Spring's `request` scope)
+- https://docs.oracle.com/javaee/7/api/javax/faces/bean/SessionScoped.html[`@jakarta.faces.bean.SessionScoped`] (mapped to Spring's `session` scope)
+- https://docs.oracle.com/javaee/7/api/javax/faces/bean/ViewScoped.html[`@jakarta.faces.bean.ViewScoped`] (mapped to Joinfaces' `view` scope)
 
 ==== CDI Annotations
 
-- https://docs.oracle.com/javaee/7/api/javax/enterprise/context/ApplicationScoped.html[`@javax.enterprise.context.ApplicationScoped`] (mapped to Spring's `application` scope)
-- https://docs.oracle.com/javaee/7/api/javax/enterprise/context/ConversationScoped.html[`@javax.enterprise.context.ConversationScoped`] (mapped to Spring's `session` scope)
-- https://docs.oracle.com/javaee/7/api/javax/enterprise/context/RequestScoped.html[`@javax.enterprise.context.RequestScoped`] (mapped to Spring's `request` scope)
-- https://docs.oracle.com/javaee/7/api/javax/enterprise/context/SessionScoped.html[`@javax.enterprise.context.SessionScoped`] (mapped to Spring's `session` scope)
+- https://docs.oracle.com/javaee/7/api/javax/enterprise/context/ApplicationScoped.html[`@jakarta.enterprise.context.ApplicationScoped`] (mapped to Spring's `application` scope)
+- https://docs.oracle.com/javaee/7/api/javax/enterprise/context/ConversationScoped.html[`@jakarta.enterprise.context.ConversationScoped`] (mapped to Spring's `session` scope)
+- https://docs.oracle.com/javaee/7/api/javax/enterprise/context/RequestScoped.html[`@jakarta.enterprise.context.RequestScoped`] (mapped to Spring's `request` scope)
+- https://docs.oracle.com/javaee/7/api/javax/enterprise/context/SessionScoped.html[`@jakarta.enterprise.context.SessionScoped`] (mapped to Spring's `session` scope)
 
 === Spring Security JSF Facelet Tag support
 


### PR DESCRIPTION
There were some parts in the documentation where javax.x instead of the new jakarta.x package names were mentioned. This pr fixes this.