### PR TITLE
refactor scenarios to add resource sets to tomcat in order to find faces resources

### DIFF
--- a/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/tomcat/TomcatRuntime.java
+++ b/joinfaces-autoconfigure/src/main/java/org/joinfaces/autoconfigure/tomcat/TomcatRuntime.java
@@ -23,13 +23,9 @@ package org.joinfaces.autoconfigure.tomcat;
  */
 public enum TomcatRuntime  {
 	/**
-	 * Runtime jar inside IDE.
+	 * Runtime jar with main class, jar launcher or test.
 	 */
-	UNPACKAGED_JAR,
-	/**,
-	 * Runtime jar testing or war testing.
-	 */
-	TEST,
+	UNPACKAGED,
 	/**
 	 * Runtime java -jar jar packaging.
 	 */
@@ -37,9 +33,5 @@ public enum TomcatRuntime  {
 	/**
 	 * Runtime java -jar war packaging.
 	 */
-	UBER_WAR,
-	/**
-	 * Runtime war inside tomcat servlet container.
-	 */
-	UNPACKAGED_WAR
+	UBER_WAR
 }

--- a/joinfaces-autoconfigure/src/test/java/org/joinfaces/autoconfigure/tomcat/JsfTomcatLifecycleListenerIT.java
+++ b/joinfaces-autoconfigure/src/test/java/org/joinfaces/autoconfigure/tomcat/JsfTomcatLifecycleListenerIT.java
@@ -119,21 +119,6 @@ public class JsfTomcatLifecycleListenerIT {
 	}
 
 	@Test
-	public void testingResources() throws LifecycleException {
-		ContextMock contextMock = new ContextMock();
-
-		DirResourceSet dirResourceSet = new DirResourceSet(contextMock.getWebResourceRoot(),
-			TEST, TEST, TEST);
-
-		contextMock.init(dirResourceSet);
-
-		callApplicationEvent(contextMock);
-
-		assertThat(contextMock.getWebResourceRoot().getCreateWebResourceSetCalls())
-			.isEqualTo(0);
-	}
-
-	@Test
 	public void embeddedJarWithoutAppResources() throws LifecycleException {
 		ContextMock contextMock = new ContextMock();
 


### PR DESCRIPTION
Depending on how we run Spring Boot with Tomcat (packaged jar, packaged war, unpackaged), JsfTomcatLifecycleListener adds resources to enable Tomcat to find Faces resources.

Usually, if one of the resource sets of Tomcat is DirResourceSet, nothing is done because Tomcat can find Faces resources with it. However, if this resource set contains a BOOT-INF folder, it does not contain Faces resources, and it is necessary to add classpath resource sets.

Build of joinfaces-gradle-jar-example creates an empty dir BOOT-INF/classes/META-INF/resources. Tomcat identified this folder as DirResourceSet. It was blocking JsfTomcatLifecycleListener from adding the faces resources folder META-INF/resources.

This PR is a tentative to solve #1969

