### PR TITLE
Add dependabot to track 5.3.x branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,11 @@ version: 2
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
+    target-branch: "5.3.x"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gradle"
+    directory: "/"
     target-branch: "5.2.x"
     schedule:
       interval: "daily"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Joinfaces | Java           | Spring Boot | JSF / Faces
 `5.0.x`   | `17` to `19`   | `3.0`       |`3.0` to `4.0`
 `5.1.x`   | `17` to `20`   | `3.1`       |`3.0` to `4.0`
 `5.2.x`   | `17` to `21`   | `3.2`       |`3.0` to `4.0`
+`5.3.x`   | `17` to `21`   | `3.3`       |`3.0` to `4.0`
 
 This are the combinations we have tested and expect to work, but depending on the features you are using, other combinations might work, too.
 When using Java 9 or higher, make sure to use JoinFaces only on the classpath and not on the modulepath.


### PR DESCRIPTION
And update readme system requirements table to include 5.3.x versions.