### PR TITLE
MatchMode.BETWEEN implementation

### DIFF
--- a/joinfaces/src/main/java/org/joinfaces/primefaces/SpringDataJpaLazyDataModel.java
+++ b/joinfaces/src/main/java/org/joinfaces/primefaces/SpringDataJpaLazyDataModel.java
@@ -16,6 +16,9 @@
 
 package org.joinfaces.primefaces;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -158,6 +161,13 @@ public class SpringDataJpaLazyDataModel<T, ID, R extends JpaRepository<T, ID> & 
 				case GREATER_THAN_EQUALS -> {
 					return criteriaBuilder.greaterThanOrEqualTo((Path<Comparable>) path, (Comparable) filterValue);
 				}
+				case BETWEEN -> {
+					List<LocalDate> list = (List) filterValue;
+					Date dateI = convertToDateViaInstant(list.get(0));
+					Date dateII = convertToDateViaInstant(list.get(1));
+					return criteriaBuilder.between(root.get(filterMeta.getField()),
+						criteriaBuilder.literal(dateI), criteriaBuilder.literal(dateII));
+				}
 				default ->
 					throw new IllegalArgumentException("MatchMode " + filterMeta.getMatchMode() + " is not supported");
 			}
@@ -170,6 +180,12 @@ public class SpringDataJpaLazyDataModel<T, ID, R extends JpaRepository<T, ID> & 
 				path = path.get(part);
 			}
 			return (Path<P>) path;
+		}
+
+		protected static Date convertToDateViaInstant(LocalDate dateToConvert) {
+			return Date.from(dateToConvert.atStartOfDay()
+				.atZone(ZoneId.systemDefault())
+				.toInstant());
 		}
 	}
 }

--- a/joinfaces/src/test/java/org/joinfaces/primefaces/Person.java
+++ b/joinfaces/src/test/java/org/joinfaces/primefaces/Person.java
@@ -37,9 +37,9 @@ public class Person implements Persistable<UUID> {
 
 	private String name;
 
-	private LocalDate birthday;
+	private LocalDate birthday = LocalDate.of(2000, 1, 1);
 
-	private int size;
+	private int size = 180;
 
 	@Override
 	public boolean isNew() {

--- a/joinfaces/src/test/java/org/joinfaces/primefaces/SpringDataJpaLazyDataModelTest.java
+++ b/joinfaces/src/test/java/org/joinfaces/primefaces/SpringDataJpaLazyDataModelTest.java
@@ -16,6 +16,7 @@
 
 package org.joinfaces.primefaces;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -25,13 +26,15 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.primefaces.model.FilterMeta;
+import org.primefaces.model.MatchMode;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
+@SpringBootTest(properties = {"spring.jpa.show-sql=true", "logging.level.sql=debug"})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SpringDataJpaLazyDataModelTest {
 
@@ -59,6 +62,7 @@ class SpringDataJpaLazyDataModelTest {
 
 		assertThat(load).isNotEmpty();
 	}
+
 	@Test
 	void testRowKeys() {
 
@@ -74,6 +78,84 @@ class SpringDataJpaLazyDataModelTest {
 		}
 
 		assertThat(dataModel.getIdClass()).isEqualTo(UUID.class);
+	}
+
+	@Test
+	void testBetweenInt() {
+
+		FilterMeta filterMeta = FilterMeta.builder()
+			.field("size")
+			.matchMode(MatchMode.BETWEEN)
+			.filterValue(List.of(100, 200))
+			.build();
+		List<Person> load = dataModel.load(0, 10, Map.of(), Map.of("size", filterMeta));
+
+		assertThat(load).isNotEmpty();
+	}
+
+	@Test
+	void testNotBetweenInt() {
+
+		FilterMeta filterMeta = FilterMeta.builder()
+			.field("size")
+			.matchMode(MatchMode.NOT_BETWEEN)
+			.filterValue(List.of(100, 200))
+			.build();
+		List<Person> load = dataModel.load(0, 10, Map.of(), Map.of("size", filterMeta));
+
+		assertThat(load).isEmpty();
+	}
+
+	@Test
+	void testBetweenDate() {
+
+		FilterMeta filterMeta = FilterMeta.builder()
+			.field("birthday")
+			.matchMode(MatchMode.BETWEEN)
+			.filterValue(List.of(LocalDate.of(1990, 1, 1), LocalDate.now()))
+			.build();
+		List<Person> load = dataModel.load(0, 10, Map.of(), Map.of("birthday", filterMeta));
+
+		assertThat(load).isNotEmpty();
+	}
+
+	@Test
+	void testNotBetweenDate() {
+
+		FilterMeta filterMeta = FilterMeta.builder()
+			.field("birthday")
+			.matchMode(MatchMode.NOT_BETWEEN)
+			.filterValue(List.of(LocalDate.of(1990, 1, 1), LocalDate.now()))
+			.build();
+		List<Person> load = dataModel.load(0, 10, Map.of(), Map.of("birthday", filterMeta));
+
+		assertThat(load).isEmpty();
+	}
+
+	@Test
+	void testBetweenDate_noMatch() {
+
+		FilterMeta filterMeta = FilterMeta.builder()
+			.field("birthday")
+			.matchMode(MatchMode.BETWEEN)
+			.filterValue(List.of(LocalDate.of(2005, 1, 1), LocalDate.now()))
+			.build();
+		List<Person> load = dataModel.load(0, 10, Map.of(), Map.of("birthday", filterMeta));
+
+		assertThat(load).isEmpty();
+	}
+
+	@Test
+	void testNotBetweenDate_noMatch() {
+
+		FilterMeta filterMeta = FilterMeta.builder()
+			.field("birthday")
+			.matchMode(MatchMode.NOT_BETWEEN)
+			.filterValue(List.of(LocalDate.of(2005, 1, 1), LocalDate.now()))
+			.build();
+		List<Person> load = dataModel.load(0, 10, Map.of(), Map.of("birthday", filterMeta));
+
+		assertThat(load).isNotEmpty();
 	}
 
 	@AfterAll


### PR DESCRIPTION
I'm sending a MatchMode.BETWEEN implementation for SpringDataJpaLazyDataModel.
Example:
 <p:column      headerText="Data do Pagamento"
                        sortBy="#{obj.pagoEm}"
                        field="pagoEm"
                        filterMatchMode="between">
                <f:facet name="filter">
                    <p:datePicker flex="true" readonlyInput="true" selectionMode="range" styleClass="ui-custom-filter"/>
                </f:facet>
                    <commons:outputTextDate value="#{obj.pagoEm}"/>
                </p:column>